### PR TITLE
空文字と null わける必要がなさそうだったので null を廃止

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -230,15 +229,15 @@ func csvToCoursesStruct(reader io.ReadCloser) ([]Courses, error) {
 			StandardRegistrationYear: standardRegistrationYearParser,
 			Term:                     termInt,
 			Period:                   period,
-			Classroom:                newSQLNullString(row.Classroom),
+			Classroom:                row.Classroom,
 			Instructor:               instructor,
-			CourseOverview:           newSQLNullString(row.CourseOverview),
-			Remarks:                  newSQLNullString(row.Remarks),
+			CourseOverview:           row.CourseOverview,
+			Remarks:                  row.Remarks,
 			CreditedAuditors:         creditedAuditors,
-			ApplicationConditions:    newSQLNullString(row.ApplicationConditions),
-			AltCourseName:            newSQLNullString(row.AltCourseName),
-			CourseCode:               newSQLNullString(row.CourseCode),
-			CourseCodeName:           newSQLNullString(row.CourseCodeName),
+			ApplicationConditions:    row.ApplicationConditions,
+			AltCourseName:            row.AltCourseName,
+			CourseCode:               row.CourseCode,
+			CourseCodeName:           row.CourseCodeName,
 			CSVUpdatedAt:             csvUpdatedAt,
 			Year:                     year,
 			CreatedAt:                now,
@@ -247,16 +246,6 @@ func csvToCoursesStruct(reader io.ReadCloser) ([]Courses, error) {
 		courses = append(courses, s)
 	}
 	return courses, nil
-}
-
-func newSQLNullString(s string) sql.NullString {
-	if s == "" {
-		return sql.NullString{String: "", Valid: false}
-	}
-	return sql.NullString{
-		String: s,
-		Valid:  true,
-	}
 }
 
 func execMigrate() error {
@@ -280,26 +269,26 @@ func insert(tx *sqlx.Tx, courses []Courses) error {
 	// UNIQUE 指定すれば、確認しなくてもよいらしい（？）
 
 	type insertPrepare struct {
-		CourseNumber             string         `db:"course_number"`
-		CourseName               string         `db:"course_name"`
-		InstructionalType        int            `db:"instructional_type"`
-		Credits                  string         `db:"credits"`
-		StandardRegistrationYear interface{}    `db:"standard_registration_year"`
-		Term                     interface{}    `db:"term"`
-		Period                   interface{}    `db:"period_"`
-		Classroom                sql.NullString `db:"classroom"`
-		Instructor               interface{}    `db:"instructor"`
-		CourseOverview           sql.NullString `db:"course_overview"`
-		Remarks                  sql.NullString `db:"remarks"`
-		CreditedAuditors         int            `db:"credited_auditors"`
-		ApplicationConditions    sql.NullString `db:"application_conditions"`
-		AltCourseName            sql.NullString `db:"alt_course_name"`
-		CourseCode               sql.NullString `db:"course_code"`
-		CourseCodeName           sql.NullString `db:"course_code_name"`
-		CSVUpdatedAt             time.Time      `db:"csv_updated_at"`
-		Year                     int            `db:"year"`
-		CreatedAt                time.Time      `db:"created_at"`
-		UpdatedAt                time.Time      `db:"updated_at"`
+		CourseNumber             string      `db:"course_number"`
+		CourseName               string      `db:"course_name"`
+		InstructionalType        int         `db:"instructional_type"`
+		Credits                  string      `db:"credits"`
+		StandardRegistrationYear interface{} `db:"standard_registration_year"`
+		Term                     interface{} `db:"term"`
+		Period                   interface{} `db:"period_"`
+		Classroom                string      `db:"classroom"`
+		Instructor               interface{} `db:"instructor"`
+		CourseOverview           string      `db:"course_overview"`
+		Remarks                  string      `db:"remarks"`
+		CreditedAuditors         int         `db:"credited_auditors"`
+		ApplicationConditions    string      `db:"application_conditions"`
+		AltCourseName            string      `db:"alt_course_name"`
+		CourseCode               string      `db:"course_code"`
+		CourseCodeName           string      `db:"course_code_name"`
+		CSVUpdatedAt             time.Time   `db:"csv_updated_at"`
+		Year                     int         `db:"year"`
+		CreatedAt                time.Time   `db:"created_at"`
+		UpdatedAt                time.Time   `db:"updated_at"`
 	}
 
 	// 全て（約 19,000 件）を一気に insert しようとしたら制限に引っかかった

--- a/migrations/20210619141018-init.sql
+++ b/migrations/20210619141018-init.sql
@@ -18,17 +18,17 @@ create table if not exists courses (
 		instructional_type instructional_type not null, -- 授業方法
 		credits varchar(8) not null, -- 単位数
 		standard_registration_year standard_registration_year[] not null, -- 標準履修年次
-		term int[], -- 開講時期
+		term int[] not null, -- 開講時期
 		period_ varchar(16)[] not null, -- 曜時限
-		classroom varchar(256), -- 教室
+		classroom varchar(256) not null, -- 教室
 		instructor varchar(256)[] not null, -- 担当教員
-		course_overview text, -- 授業概要
-		remarks text, -- 備考
+		course_overview text not null, -- 授業概要
+		remarks text not null, -- 備考
 		credited_auditors credited_auditors not null, -- 科目履修生申請可否
-		application_conditions varchar(256), -- 申請条件
-		alt_course_name varchar(256), -- 英語（日本語）科目名
-		course_code varchar(16), -- 科目コード
-		course_code_name varchar(256), -- 要件科目名
+		application_conditions varchar(256) not null, -- 申請条件
+		alt_course_name varchar(256) not null, -- 英語（日本語）科目名
+		course_code varchar(16) not null, -- 科目コード
+		course_code_name varchar(256) not null, -- 要件科目名
 		csv_updated_at timestamp with time zone not null, -- csvに記載されている更新日時
     year int not null, -- 何年度にエクスポートした CSV であるか
 		created_at timestamp with time zone not null, -- 最初のデータ作成日時

--- a/types.go
+++ b/types.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"database/sql"
 	"time"
 )
 
@@ -41,17 +40,17 @@ type Courses struct {
 	// 対応付けを別に持つ
 	Term []int `db:"term"`
 	// 例：月1, 月2
-	Period         []string       `db:"period_"`
-	Classroom      sql.NullString `db:"classroom"`
-	Instructor     []string       `db:"instructor"`
-	CourseOverview sql.NullString `db:"course_overview"`
-	Remarks        sql.NullString `db:"remarks"`
+	Period         []string `db:"period_"`
+	Classroom      string   `db:"classroom"`
+	Instructor     []string `db:"instructor"`
+	CourseOverview string   `db:"course_overview"`
+	Remarks        string   `db:"remarks"`
 	// 0 = 'x', 1 = 三角, 2 = ''
-	CreditedAuditors      int            `db:"credited_auditors"`
-	ApplicationConditions sql.NullString `db:"application_conditions"`
-	AltCourseName         sql.NullString `db:"alt_course_name"`
-	CourseCode            sql.NullString `db:"course_code"`
-	CourseCodeName        sql.NullString `db:"course_code_name"`
+	CreditedAuditors      int    `db:"credited_auditors"`
+	ApplicationConditions string `db:"application_conditions"`
+	AltCourseName         string `db:"alt_course_name"`
+	CourseCode            string `db:"course_code"`
+	CourseCodeName        string `db:"course_code_name"`
 	// CSV 上にある「データ更新日」
 	CSVUpdatedAt time.Time `db:"csv_updated_at"`
 	Year         int       `db:"year"`


### PR DESCRIPTION
- 空文字と null わける必要がなさそうだったので null を廃止した
- `migrations` のは新規に sql ファイルを作成してやるべきな気がするが、一度 DB を破壊して再度流し込むのでも問題ないデータなので、既存の migrations のを編集した